### PR TITLE
Change namespace to app

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ const loadHtml = () => {
     let domain = null;
     const scripts = document.getElementsByTagName("script");
     [].every.call(scripts, (script: HTMLScriptElement) => {
-        const m = script.src.match(/^(.*)?\/assets\/build\/kwf-react-starter/);
+        const m = script.src.match(/^(.*)?\/assets\/build\/app/);
         if (m) {
             domain = m[1];
             return false;
@@ -16,7 +16,7 @@ const loadHtml = () => {
     if (domain === null) return false;
     __webpack_public_path__ = domain + __webpack_public_path__;
 
-    const baseEl: HTMLElement = document.querySelector("kwf-react-starter");
+    const baseEl: HTMLElement = document.querySelector("app");
     if (!baseEl) return false;
 
     app.render(baseEl, {

--- a/public/index.html
+++ b/public/index.html
@@ -8,12 +8,12 @@
 </head>
 <body>
     <div id="page">
-        <kwf-react-starter />
+        <app />
         <script type="text/javascript">
           (function () {
             window.__KWF_REACT_STARTER_ENV__ = 'dev';
             var script = document.createElement('script');
-            script.src = "/assets/build/kwf-react-starter.js";
+            script.src = "/assets/build/app.js";
             script.async = 1;
             document.head.appendChild(script);
           })();

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -35,7 +35,7 @@ const config = ({ production }: IEnvironment): webpack.Configuration => {
     return {
         mode: production ? "production" : "development",
         entry: {
-            "kwf-react-starter": ["./index.ts"],
+            app: ["./index.ts"],
         },
         module: {
             rules: [


### PR DESCRIPTION
Der "Starter" ist ja nur am Anfang ein Starter, am Ende wird eine fertige Anwendung integriert und nicht ein Starter, daher find ich diese Einbindung besser:

`<app>
`
statt:

` <kwf-react-starter>`